### PR TITLE
Upgrade PDBs to policy/v1 prior to EKS upgrade

### DIFF
--- a/kustomize/overlays/production/disruptionbudget.yaml
+++ b/kustomize/overlays/production/disruptionbudget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: krew-installer

--- a/kustomize/overlays/staging/disruptionbudget.yaml
+++ b/kustomize/overlays/staging/disruptionbudget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: krew-installer


### PR DESCRIPTION
Updates Kustomize overlays for PodDisruptionBudgets to meet requirements in EKS 1.25. The API version `policy/v1beta` is deprecated and removed in 1.25.